### PR TITLE
Optimize standings call for standings_controller

### DIFF
--- a/app/controllers/standings_controller.rb
+++ b/app/controllers/standings_controller.rb
@@ -2,6 +2,6 @@ class StandingsController < ApplicationController
   def show
     @season = Season.find(params[:id])
     authorize(@season)
-    @standings = @season.standings
+    @standings = @season.full_stats_standings
   end
 end


### PR DESCRIPTION
This will only add extra stats onto the standings where it is needed: on the standings#index page.

A lot of other places call standings but don't actually need the extra statistics added, resulting in slower page loads for stats that will not be used.